### PR TITLE
Add navigation arrows to Today card

### DIFF
--- a/script.js
+++ b/script.js
@@ -31,6 +31,7 @@ const companionDataUrl = "https://script.google.com/macros/s/AKfycbw3fpGf2W8ANwI
 let marathonPlan = null; // Stores the entire JSON object from the Google Sheet.
 let datedTrainingPlan = []; // Stores each day of the plan with a specific date.
 let currentRaceDate = null; // The calculated date of the race.
+let currentTodayViewDate = null; // Stores the date currently displayed in the "Today's Training" card.
 let calendarCurrentDisplayDate = new Date(); // The month/year the calendar is currently showing.
 let raceElevationChartInstance = null; // Chart.js instance for the elevation profile.
 let mileageChartInstance = null; // Chart.js instance for the weekly mileage.
@@ -296,6 +297,10 @@ function initializeApp() {
     if(mainAppWrapper) mainAppWrapper.classList.remove('hidden');
     if(loginContainer) loginContainer.classList.add('hidden');
 
+    // Initialize currentTodayViewDate to today
+    currentTodayViewDate = new Date();
+    currentTodayViewDate.setHours(0, 0, 0, 0);
+
     // Show the updates modal after the main app is visible.
     showUpdatesModalIfNeeded();
 }
@@ -529,17 +534,37 @@ function renderTodaysTraining() {
         }
     }
 
-    const today = new Date();
-    today.setHours(0,0,0,0);
+    // Use currentTodayViewDate, default to actual today if not set
+    const displayDate = currentTodayViewDate ? new Date(currentTodayViewDate) : new Date();
+    displayDate.setHours(0,0,0,0);
+
     const todaysActivity = datedTrainingPlan.find(item => {
         const itemDate = new Date(item.date);
         itemDate.setHours(0,0,0,0);
-        return isSameDay(itemDate, today);
+        return isSameDay(itemDate, displayDate);
     });
 
     let activityContentHtml = '';
-    let titleHtml = `<h3 class="text-2xl font-semibold text-sky-700 mb-1 text-center">Today</h3>
-                               <p class="text-xs text-stone-500 text-center mb-3">${formatDate(today, { weekday: 'long', month: 'long', day: 'numeric' })}</p>`;
+    const isActualToday = isSameDay(displayDate, new Date(new Date().setHours(0,0,0,0)));
+    const titleText = isActualToday ? "Today" : formatDate(displayDate, { weekday: 'short' });
+
+    // Navigation arrows HTML
+    const navArrowsHtml = `
+        <div class="flex justify-between items-center w-full">
+            <button id="todayPrevDay" class="p-1 text-sky-700 hover:text-sky-500 disabled:opacity-30">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" /></svg>
+            </button>
+            <div class="text-center">
+                <h3 class="text-2xl font-semibold text-sky-700 mb-1">${titleText}</h3>
+                <p class="text-xs text-stone-500 mb-3">${formatDate(displayDate, { weekday: 'long', month: 'long', day: 'numeric' })}</p>
+            </div>
+            <button id="todayNextDay" class="p-1 text-sky-700 hover:text-sky-500 disabled:opacity-30">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" /></svg>
+            </button>
+        </div>
+    `;
+
+    let titleHtml = `<div class="relative">${navArrowsHtml}</div>`;
     let notesBoxHtml = '';
     const todayCard = document.getElementById('todays-training-card'); // Re-fetch
 
@@ -572,12 +597,12 @@ function renderTodaysTraining() {
             `;
         }
     } else {
-        let message = "No training scheduled for today.";
+        let message = `No training scheduled for ${formatDate(displayDate, { month: 'short', day: 'numeric' })}.`;
         if (marathonPlan && marathonPlan.settings && marathonPlan.settings.planStartDate) {
             const planStartDate = new Date(marathonPlan.settings.planStartDate + "T00:00:00");
-            if (isValidDate(planStartDate) && today < planStartDate) {
+            if (isValidDate(planStartDate) && displayDate < planStartDate) {
                 message = `Plan starts on ${formatDate(planStartDate)}. No training scheduled yet.`;
-            } else if (currentRaceDate && isValidDate(currentRaceDate) && today > currentRaceDate) {
+            } else if (currentRaceDate && isValidDate(currentRaceDate) && displayDate > currentRaceDate) {
                  message = `Plan ended on ${formatDate(currentRaceDate)}. No training scheduled.`;
             }
         }
@@ -599,6 +624,54 @@ function renderTodaysTraining() {
         </div>
     `;
     container.innerHTML = titleHtml + activityContentHtml + notesBoxHtml + paceCalculatorHtml;
+
+    // Add event listeners for new navigation arrows
+    const prevDayBtn = document.getElementById('todayPrevDay');
+    const nextDayBtn = document.getElementById('todayNextDay');
+
+    if (prevDayBtn) {
+        prevDayBtn.addEventListener('click', () => {
+            if (currentTodayViewDate && datedTrainingPlan.length > 0) {
+                const firstPlanDate = new Date(datedTrainingPlan[0].date);
+                firstPlanDate.setHours(0,0,0,0);
+                if (!isSameDay(currentTodayViewDate, firstPlanDate)) {
+                    currentTodayViewDate = addDays(currentTodayViewDate, -1);
+                    renderTodaysTraining();
+                }
+            }
+        });
+    }
+    if (nextDayBtn) {
+        nextDayBtn.addEventListener('click', () => {
+            if (currentTodayViewDate && datedTrainingPlan.length > 0) {
+                const lastPlanDate = new Date(datedTrainingPlan[datedTrainingPlan.length - 1].date);
+                lastPlanDate.setHours(0,0,0,0);
+                if (!isSameDay(currentTodayViewDate, lastPlanDate)) {
+                    currentTodayViewDate = addDays(currentTodayViewDate, +1);
+                    renderTodaysTraining();
+                }
+            }
+        });
+    }
+
+    // Disable navigation buttons if at the start or end of the plan
+    if (datedTrainingPlan.length > 0) {
+        const firstPlanDate = new Date(datedTrainingPlan[0].date);
+        firstPlanDate.setHours(0,0,0,0);
+        const lastPlanDate = new Date(datedTrainingPlan[datedTrainingPlan.length - 1].date);
+        lastPlanDate.setHours(0,0,0,0);
+
+        if (prevDayBtn) {
+            prevDayBtn.disabled = isSameDay(displayDate, firstPlanDate);
+        }
+        if (nextDayBtn) {
+            nextDayBtn.disabled = isSameDay(displayDate, lastPlanDate);
+        }
+    } else {
+        if (prevDayBtn) prevDayBtn.disabled = true;
+        if (nextDayBtn) nextDayBtn.disabled = true;
+    }
+
 
     if (marathonPlan && marathonPlan.settings) {
         renderTodayPaces(marathonPlan.settings.defaultLt2Speed, todaysActivity);

--- a/style.css
+++ b/style.css
@@ -1454,3 +1454,44 @@ body.dark-mode .today-pace-table td.text-green-600 { color: #68d391 !important; 
 body.dark-mode .today-pace-table td.text-sky-600 { color: #7fccff !important; }
 body.dark-mode .today-pace-table td.text-lime-600 { color: #a8e977 !important; }
 /* Add other specific zone colors if they exist and are different from the general activity-text overrides */
+
+/* --- Today Card Navigation Arrows --- */
+#todayPrevDay,
+#todayNextDay {
+    /* Tailwind classes p-1, text-sky-700, hover:text-sky-500, disabled:opacity-30 are already applied in JS */
+    /* Adding subtle background on hover and ensuring good tap targets */
+    border-radius: 0.375rem; /* rounded-md */
+    transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out, opacity 0.2s ease-in-out;
+}
+
+#todayPrevDay:not(:disabled):hover,
+#todayNextDay:not(:disabled):hover {
+    background-color: var(--nav-button-hover-bg); /* Using existing variable for hover background */
+}
+
+/* Ensure SVG icon color inherits button text color, especially for hover/disabled states */
+#todayPrevDay svg,
+#todayNextDay svg {
+    stroke: currentColor; /* Make SVG color same as button text color */
+}
+
+/* Disabled state is largely handled by Tailwind's disabled:opacity-30 */
+#todayPrevDay:disabled,
+#todayNextDay:disabled {
+    cursor: not-allowed;
+}
+
+/* Dark mode considerations for arrows if not covered by global text overrides */
+body.dark-mode #todayPrevDay:not(:disabled),
+body.dark-mode #todayNextDay:not(:disabled) {
+    color: var(--dm-title-marathon-text); /* Using sky-400 equivalent for dark mode */
+}
+
+body.dark-mode #todayPrevDay:not(:disabled):hover,
+body.dark-mode #todayNextDay:not(:disabled):hover {
+    background-color: var(--dm-nav-button-hover-bg); /* Dark mode hover background */
+    color: var(--dm-nav-button-hover-text);
+}
+
+/* The title area for Today card uses: <div class="flex justify-between items-center w-full">
+   This should already handle layout well. These CSS rules are mostly for subtle enhancements. */


### PR DESCRIPTION
This commit introduces forward and backward navigation arrows to the "Today's Training" card, allowing you to view training plans for previous and upcoming days.

Key changes:
- Modified `renderTodaysTraining()` in `script.js`:
    - Added HTML for navigation arrows.
    - Implemented logic to update the displayed day using a new `currentTodayViewDate` global variable.
    - The card title now dynamically updates to "Today" or the specific day's name and date.
    - Navigation is bounded by the start and end dates of the `datedTrainingPlan`, with arrows disabling appropriately.
- Updated `style.css`:
    - Added styles for the navigation arrows, ensuring visual consistency with the existing theme in both light and dark modes.
    - Included styles for hover and disabled states of the arrows.

The functionality has been reviewed for correctness, including date handling, boundary conditions, and integration with existing card features.