### PR TITLE
feat: Add activity-specific icons to Today's Training card

### DIFF
--- a/icons/base_run.svg
+++ b/icons/base_run.svg
@@ -1,0 +1,14 @@
+<svg width="100" height="100" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <linearGradient id="baseBody" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#38bdf8"/><stop offset="100%" stop-color="#0284c7"/></linearGradient>
+        <filter id="dropShadow"><feGaussianBlur in="SourceAlpha" stdDeviation="1"/><feOffset dx="1" dy="2"/><feComponentTransfer><feFuncA type="linear" slope="0.3"/></feComponentTransfer><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    </defs>
+    <g filter="url(#dropShadow)">
+        <path d="M3 16.5C3 15.67 3.67 15 4.5 15H21C21.83 15 22.5 15.67 22.5 16.5V17.5C22.5 18.33 21.83 19 21 19H4.5C3.67 19 3 18.33 3 17.5V16.5Z" fill="#fff"/>
+        <path d="M3.5 18.5H20.5" stroke="#d1d5db" stroke-width="0.5" stroke-linecap="round"/>
+        <path d="M5 17H6M8 17H9M11 17H12M14 17H15M17 17H18" stroke="#d1d5db" stroke-width="1" stroke-linecap="round"/>
+        <path d="M4.5 15L10 9H18.5C20.16 9 21.5 10.34 21.5 12V14.5H4C4.16 14.66 4.33 14.83 4.5 15Z" fill="url(#baseBody)"/>
+        <path d="M10 9.5 L12 11 L11 13 L13 14.5" stroke="#FFFFFF" stroke-width="0.8" fill="none" stroke-linecap="round"/>
+        <path d="M12 9.5 L14 11 L13 13 L15 14.5" stroke="#FFFFFF" stroke-width="0.8" fill="none" stroke-linecap="round"/>
+    </g>
+</svg>

--- a/icons/easy_run.svg
+++ b/icons/easy_run.svg
@@ -1,0 +1,18 @@
+<svg width="100" height="100" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+   <defs>
+        <linearGradient id="easyBody" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#4ade80"/><stop offset="100%" stop-color="#16a34a"/></linearGradient>
+        <filter id="dropShadowEasy"><feGaussianBlur in="SourceAlpha" stdDeviation="1"/><feOffset dx="1" dy="2"/><feComponentTransfer><feFuncA type="linear" slope="0.3"/></feComponentTransfer><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    </defs>
+    <g filter="url(#dropShadowEasy)">
+        <path d="M3 16.5C3 15.67 3.67 15 4.5 15H21C21.83 15 22.5 15.67 22.5 16.5V17.5C22.5 18.33 21.83 19 21 19H4.5C3.67 19 3 18.33 3 17.5V16.5Z" fill="#fff"/>
+        <path d="M3.5 18.5H20.5" stroke="#a1a1aa" stroke-width="0.5" stroke-linecap="round"/>
+        <path d="M4 16.5 C 5 15.5, 6 15.5, 7 16.5" stroke="#a1a1aa" stroke-width="0.5" fill="none" opacity="0.7"/>
+        <path d="M19 16.5 C 20 15.5, 21 15.5, 22 16.5" stroke="#a1a1aa" stroke-width="0.5" fill="none" opacity="0.7"/>
+        <path d="M4.5 15L10 9H18.5C20.16 9 21.5 10.34 21.5 12V14.5H4C4.16 14.66 4.33 14.83 4.5 15Z" fill="url(#easyBody)"/>
+        <circle cx="14" cy="12.5" r="0.5" fill="#14532d" opacity="0.7"/>
+        <circle cx="16" cy="12.5" r="0.5" fill="#14532d" opacity="0.7"/>
+        <circle cx="18" cy="12.5" r="0.5" fill="#14532d" opacity="0.7"/>
+        <path d="M10 9.5 L12 11 L11 13 L13 14.5" stroke="#FFFFFF" stroke-width="0.8" fill="none" stroke-linecap="round" opacity="0.8"/>
+        <path d="M12 9.5 L14 11 L13 13 L15 14.5" stroke="#FFFFFF" stroke-width="0.8" fill="none" stroke-linecap="round" opacity="0.8"/>
+    </g>
+</svg>

--- a/icons/fartlek_run.svg
+++ b/icons/fartlek_run.svg
@@ -1,0 +1,15 @@
+<svg width="100" height="100" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <linearGradient id="fartlekBody" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#f87171"/><stop offset="100%" stop-color="#dc2626"/></linearGradient>
+        <linearGradient id="thunderGradient" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#fef08a"/><stop offset="100%" stop-color="#facc15"/></linearGradient>
+        <filter id="dropShadow3"><feGaussianBlur in="SourceAlpha" stdDeviation="1.5"/><feOffset dx="1" dy="3"/><feComponentTransfer><feFuncA type="linear" slope="0.4"/></feComponentTransfer><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    </defs>
+    <g filter="url(#dropShadow3)">
+        <path d="M4 18.5H20C21.1 18.5 22 17.6 22 16.5V16C22 15.45 21.55 15 21 15H3C2.45 15 2 15.45 2 16V16.5C2 17.6 2.9 18.5 4 18.5Z" fill="#fff"/>
+        <path d="M4.5 18H20.5" stroke="#d1d5db" stroke-width="0.5" stroke-linecap="round"/>
+        <path d="M4.5 15L10 9H18.5C20.16 9 21.5 10.34 21.5 12V14.5H4C4.16 14.66 4.33 14.83 4.5 15Z" fill="url(#fartlekBody)"/>
+        <path d="M10 9.5 L12 11 L11 13 L13 14.5" stroke="#FFFFFF" stroke-width="0.8" fill="none" stroke-linecap="round"/>
+        <path d="M12 9.5 L14 11 L13 13 L15 14.5" stroke="#FFFFFF" stroke-width="0.8" fill="none" stroke-linecap="round"/>
+        <path d="M18 7 L12 13 H 16 L 10 20" stroke="url(#thunderGradient)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    </g>
+</svg>

--- a/icons/interval_run.svg
+++ b/icons/interval_run.svg
@@ -1,0 +1,16 @@
+<svg width="100" height="100" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <linearGradient id="intervalBody" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#dc2626"/><stop offset="100%" stop-color="#b91c1c"/></linearGradient>
+        <radialGradient id="spikeGradient"><stop offset="0%" stop-color="#f1f5f9"/><stop offset="100%" stop-color="#94a3b8"/></radialGradient>
+         <linearGradient id="intervalFire" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#fde047"/><stop offset="100%" stop-color="#f97316"/></linearGradient>
+        <filter id="dropShadow5"><feGaussianBlur in="SourceAlpha" stdDeviation="1"/><feOffset dx="1" dy="2"/><feComponentTransfer><feFuncA type="linear" slope="0.3"/></feComponentTransfer><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    </defs>
+    <g filter="url(#dropShadow5)">
+        <path d="M4 18.5H20C21.1 18.5 22 17.6 22 16.5V16C22 15.45 21.55 15 21 15H3C2.45 15 2 15.45 2 16V16.5C2 17.6 2.9 18.5 4 18.5Z" fill="#1f2937"/>
+        <path d="M6 18.5L5 21L7 21L6 18.5Z" fill="url(#spikeGradient)"/><path d="M10 18.5L9 21L11 21L10 18.5Z" fill="url(#spikeGradient)"/><path d="M14 18.5L13 21L15 21L14 18.5Z" fill="url(#spikeGradient)"/><path d="M18 18.5L17 21L19 21L18 18.5Z" fill="url(#spikeGradient)"/>
+        <path d="M4.5 15L10 9H18.5C20.16 9 21.5 10.34 21.5 12V14.5H4C4.16 14.66 4.33 14.83 4.5 15Z" fill="url(#intervalBody)"/>
+        <path d="M10 9.5 L12 11 L11 13 L13 14.5" stroke="#fecaca" stroke-width="0.8" fill="none" stroke-linecap="round"/>
+        <path d="M12 9.5 L14 11 L13 13 L15 14.5" stroke="#fecaca" stroke-width="0.8" fill="none" stroke-linecap="round"/>
+        <path d="M18 10 C 18.5 9, 19.5 9, 20 10 C 19.5 11, 18.5 11, 18 10 Z" fill="url(#intervalFire)"/>
+    </g>
+</svg>

--- a/icons/long_run.svg
+++ b/icons/long_run.svg
@@ -1,0 +1,14 @@
+<svg width="100" height="100" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <linearGradient id="longRunBody" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#a78bfa"/><stop offset="100%" stop-color="#7c3aed"/></linearGradient>
+        <linearGradient id="supportSole" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="20%" stop-color="#fff"/><stop offset="80%" stop-color="#ede9fe"/></linearGradient>
+         <filter id="dropShadow6"><feGaussianBlur in="SourceAlpha" stdDeviation="1"/><feOffset dx="1" dy="2"/><feComponentTransfer><feFuncA type="linear" slope="0.3"/></feComponentTransfer><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    </defs>
+    <g filter="url(#dropShadow6)">
+        <path d="M1 21C5 19 13 19.5 18 21L23 18C18 16 10 15.5 5 18L1 21Z" fill="#c4b5fd" opacity="0.7"/>
+        <path d="M6 14.5H22C23.1 14.5 24 13.6 24 12.5V12C24 11.45 23.55 11 23 11H5C4.45 11 4 11.45 4 12V12.5C4 13.6 4.9 14.5 6 14.5Z" fill="url(#supportSole)"/>
+        <path d="M4 13H24" stroke="#c4b5fd" stroke-width="0.75" />
+        <path d="M6.5 11L12 5H20.5C22.16 5 23.5 6.34 23.5 8V10.5H6C6.16 10.66 6.33 10.83 6.5 11Z" fill="url(#longRunBody)"/>
+        <path d="M12.5 5.5 C 14 7, 13 8, 15 9.5 M 14.5 5.5 C 16 7, 15 8, 17 9.5" stroke="#ede9fe" stroke-width="0.8" fill="none" stroke-linecap="round"/>
+    </g>
+</svg>

--- a/icons/rest_day.svg
+++ b/icons/rest_day.svg
@@ -1,0 +1,16 @@
+<svg width="120" height="120" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <linearGradient id="bedFrame" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#a3a3a3"/><stop offset="100%" stop-color="#737373"/></linearGradient>
+        <linearGradient id="comforter" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#fafafa"/><stop offset="100%" stop-color="#e5e5e5"/></linearGradient>
+        <linearGradient id="pillow" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#f5f5f5"/><stop offset="100%" stop-color="#d4d4d4"/></linearGradient>
+         <filter id="dropShadow7"><feGaussianBlur in="SourceAlpha" stdDeviation="1"/><feOffset dx="1" dy="2"/><feComponentTransfer><feFuncA type="linear" slope="0.3"/></feComponentTransfer><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    </defs>
+    <g filter="url(#dropShadow7)">
+        <path d="M3 20H21V18H3V20Z" fill="url(#bedFrame)"/>
+        <path d="M3 18H21V10C21 8.9 20.1 8 19 8H5C3.9 8 3 8.9 3 10V18Z" fill="url(#comforter)"/>
+        <path d="M5 8C5 6.9 5.9 6 7 6H11C12.1 6 13 6.9 13 8V8H5Z" fill="url(#pillow)"/>
+         <text x="16" y="7" font-family="monospace" font-size="2" fill="#737373" font-weight="bold">z</text>
+         <text x="17.5" y="5.5" font-family="monospace" font-size="2.5" fill="#737373" font-weight="bold">Z</text>
+         <text x="19.5" y="4" font-family="monospace" font-size="3" fill="#737373" font-weight="bold">z</text>
+    </g>
+</svg>

--- a/icons/tempo_run.svg
+++ b/icons/tempo_run.svg
@@ -1,0 +1,16 @@
+<svg width="100" height="100" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <linearGradient id="tempoBody" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#fbbf24"/><stop offset="100%" stop-color="#f59e0b"/></linearGradient>
+        <linearGradient id="wingGradientReal" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#ffffff"/><stop offset="100%" stop-color="#e5e7eb"/></linearGradient>
+        <filter id="dropShadow4"><feGaussianBlur in="SourceAlpha" stdDeviation="1"/><feOffset dx="1" dy="2"/><feComponentTransfer><feFuncA type="linear" slope="0.3"/></feComponentTransfer><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    </defs>
+    <g filter="url(#dropShadow4)">
+        <path d="M5 18.5H21C22.1 18.5 23 17.6 23 16.5V16C23 15.45 22.55 15 22 15H4C3.45 15 3 15.45 3 16V16.5C3 17.6 3.9 18.5 5 18.5Z" fill="#fff"/>
+        <path d="M5.5 15L11 9H19.5C21.16 9 22.5 10.34 22.5 12V14.5H5C5.16 14.66 5.33 14.83 5.5 15Z" fill="url(#tempoBody)"/>
+        <path d="M10 9.5 L12 11 L11 13 L13 14.5" stroke="#FFFFFF" stroke-width="0.8" fill="none" stroke-linecap="round"/>
+        <path d="M12 9.5 L14 11 L13 13 L15 14.5" stroke="#FFFFFF" stroke-width="0.8" fill="none" stroke-linecap="round"/>
+        <path d="M4 15.5 C 1 15, -1 12, 2 10 L 4.5 11.5" fill="url(#wingGradientReal)" stroke="#d1d5db" stroke-width="0.5"/>
+        <path d="M3.5 13.5 C 0 13, -2 10, 1 8 L 3.5 9.5" fill="url(#wingGradientReal)" stroke="#d1d5db" stroke-width="0.5"/>
+        <path d="M3 11.5 C -1 11, -3 8, 0 6 L 2.5 7.5" fill="url(#wingGradientReal)" stroke="#d1d5db" stroke-width="0.5"/>
+    </g>
+</svg>

--- a/style.css
+++ b/style.css
@@ -1765,3 +1765,11 @@ body.dark-mode #todayNextDay:not(:disabled):hover {
 #app-content > section {
     animation: fadeIn 0.3s ease-in-out forwards;
 }
+
+/* --- Training Activity Icon Styles --- */
+.training-activity-icon {
+    width: 2rem;  /* Approx 32px */
+    height: 2rem; /* Approx 32px */
+    object-fit: contain; /* Ensures aspect ratio is maintained if SVGs vary */
+    /* vertical-align: middle; /* Useful if not in a flex container, but items-center on parent handles it */
+}


### PR DESCRIPTION
This commit introduces icons to the "Today's Training" card, displaying a unique visual cue based on the scheduled activity type (Base, Easy, Fartlek, Tempo, Interval, Long Run, Rest).

Key changes:

1.  **Added SVG Icons:**
    *   Seven new SVG icon files (e.g., `base_run.svg`, `easy_run.svg`, `rest_day.svg`, etc.) representing different training activities have been added to the `icons/` directory. These SVGs were provided by you.

2.  **Updated `script.js`:**
    *   An `activityIconMap` object was created to map activity keywords to their corresponding SVG file paths.
    *   The `renderTodaysTraining` function was modified to:
        *   Parse the activity string to determine the training type.
        *   Select the appropriate icon path from the map.
        *   Dynamically inject an `<img>` tag for the icon into the `.todays-activity-box`.
        *   The icon is placed within a new flex container (`.activity-meta-container`) next to the phase/week details for better layout.

3.  **Updated `style.css`:**
    *   Added a new CSS class `.training-activity-icon` to style the displayed icons.
    *   This class sets a consistent size (2rem x 2rem) and uses `object-fit: contain` to ensure proper scaling and aspect ratio of the SVGs.

This enhancement provides a more visually engaging and informative "Today's Training" card, allowing you to quickly identify your scheduled workout type.