### PR TITLE
feat: Add fade animation for login to main app transition

### DIFF
--- a/script.js
+++ b/script.js
@@ -365,59 +365,78 @@ function populateAndScrollRunnersList() {
 function initializeApp() {
     if(loadingMessageDiv) loadingMessageDiv.classList.add('hidden');
     if(errorMessageDiv) errorMessageDiv.classList.add('hidden');
-    if(appContent) appContent.innerHTML = '';
+    if(appContent) appContent.innerHTML = ''; // Clear previous content if any
 
-    // Add event listeners to the main navigation buttons.
-    if(navOverview) navOverview.addEventListener('click', renderOverview);
-    if(navPlan) navPlan.addEventListener('click', renderTrainingPlan);
-    if(navCalendar) navCalendar.addEventListener('click', renderCalendarTab);
-    if(navRace) navRace.addEventListener('click', renderRaceTab);
-    if(navCompanion) navCompanion.addEventListener('click', renderCompanionTab);
-    if(navInfo) navInfo.addEventListener('click', renderInfoTab);
+    // Start fade-out of login screen
+    if (loginContainer) {
+        loginContainer.classList.remove('screen-is-fading-in'); // Precaution
+        loginContainer.classList.add('screen-is-fading-out');
+    }
 
-    // Add event listeners for the mileage chart modal
-    if(mileageChartModal && closeMileageChartBtn) {
-        closeMileageChartBtn.addEventListener('click', () => {
-            mileageChartModal.classList.add('modal-hidden-state');
-            mileageChartModal.classList.remove('modal-visible-state');
-            // Optional: setTimeout(() => mileageChartModal.classList.add('hidden'), 250); // If display:none is still desired
-        });
-        mileageChartModal.addEventListener('click', (e) => {
-            if (e.target.id === 'mileage-chart-modal') {
+    setTimeout(() => {
+        if (loginContainer) {
+            loginContainer.classList.add('hidden'); // display:none after fade
+            loginContainer.classList.remove('screen-is-fading-out');
+        }
+
+        if (mainAppWrapper) {
+            mainAppWrapper.classList.remove('hidden'); // display:block/flex, but still opacity:0 due to CSS rule for #main-app-wrapper
+
+            // Brief delay for browser to render mainAppWrapper before starting fade-in
+            setTimeout(() => {
+                if (mainAppWrapper) { // Check again in case something went wrong
+                    mainAppWrapper.classList.remove('screen-is-fading-out'); // Precaution
+                    mainAppWrapper.classList.add('screen-is-fading-in'); // Start fade-in
+                }
+            }, 20);
+        }
+
+        // Original initializeApp logic (nav listeners, modal setup, initial render)
+        if(navOverview) navOverview.addEventListener('click', renderOverview);
+        if(navPlan) navPlan.addEventListener('click', renderTrainingPlan);
+        if(navCalendar) navCalendar.addEventListener('click', renderCalendarTab);
+        if(navRace) navRace.addEventListener('click', renderRaceTab);
+        if(navCompanion) navCompanion.addEventListener('click', renderCompanionTab);
+        if(navInfo) navInfo.addEventListener('click', renderInfoTab);
+
+        // Add event listeners for the mileage chart modal
+        if(mileageChartModal && closeMileageChartBtn) {
+            closeMileageChartBtn.addEventListener('click', () => {
                 mileageChartModal.classList.add('modal-hidden-state');
                 mileageChartModal.classList.remove('modal-visible-state');
-                // Optional: setTimeout(() => mileageChartModal.classList.add('hidden'), 250);
-            }
-        });
-    }
+            });
+            mileageChartModal.addEventListener('click', (e) => {
+                if (e.target.id === 'mileage-chart-modal') {
+                    mileageChartModal.classList.add('modal-hidden-state');
+                    mileageChartModal.classList.remove('modal-visible-state');
+                }
+            });
+        }
 
-    // Add event listeners for the new updates modal
-    if(updatesModal && closeUpdatesModalBtn) {
-        closeUpdatesModalBtn.addEventListener('click', () => {
-            updatesModal.classList.add('modal-hidden-state');
-            updatesModal.classList.remove('modal-visible-state');
-            // Optional: setTimeout(() => updatesModal.classList.add('hidden'), 250);
-        });
-        updatesModal.addEventListener('click', (e) => {
-             // Closes modal if user clicks on the background overlay
-            if (e.target.id === 'updates-modal') {
+        // Add event listeners for the new updates modal
+        if(updatesModal && closeUpdatesModalBtn) {
+            closeUpdatesModalBtn.addEventListener('click', () => {
                 updatesModal.classList.add('modal-hidden-state');
                 updatesModal.classList.remove('modal-visible-state');
-                // Optional: setTimeout(() => updatesModal.classList.add('hidden'), 250);
-            }
-        });
-    }
+            });
+            updatesModal.addEventListener('click', (e) => {
+                if (e.target.id === 'updates-modal') {
+                    updatesModal.classList.add('modal-hidden-state');
+                    updatesModal.classList.remove('modal-visible-state');
+                }
+            });
+        }
 
-    renderOverview(); // Render the default "Overview" tab.
-    if(mainAppWrapper) mainAppWrapper.classList.remove('hidden');
-    if(loginContainer) loginContainer.classList.add('hidden');
+        renderOverview(); // Render the default "Overview" tab.
 
-    // Initialize currentTodayViewDate to today
-    currentTodayViewDate = new Date();
-    currentTodayViewDate.setHours(0, 0, 0, 0);
+        // Initialize currentTodayViewDate to today
+        currentTodayViewDate = new Date();
+        currentTodayViewDate.setHours(0, 0, 0, 0);
 
-    // Show the updates modal after the main app is visible.
-    showUpdatesModalIfNeeded();
+        // Show the updates modal after the main app is visible.
+        showUpdatesModalIfNeeded();
+
+    }, 400); // Matches CSS transition duration (0.4s) for loginContainer fade-out
 }
 
 // --- LOGIN & DATA FETCHING ---

--- a/style.css
+++ b/style.css
@@ -1989,3 +1989,27 @@ body.dark-mode #runners-list li {
     90.01% { transform: translate(-50%, 3px) scale(0.9); left: 50%; top: 100%; opacity: 0; }
     100% { transform: translate(-50%, 3px) scale(0.9); left: 50%; top: 100%; opacity: 0; }
 }
+
+/* --- Screen Transition Styles --- */
+#login-container,
+#main-app-wrapper {
+    transition: opacity 0.4s ease-in-out;
+}
+
+/* #login-container by default is opacity: 1 if not hidden by Tailwind 'hidden' class */
+
+#main-app-wrapper {
+    /* This already has class="main-container hidden" in HTML.
+       When 'hidden' (display:none) is removed by JS, opacity 0 allows it to fade in. */
+    opacity: 0;
+}
+
+.screen-is-fading-out {
+    opacity: 0 !important;
+    pointer-events: none !important; /* Prevent interaction during/after fade-out */
+}
+
+.screen-is-fading-in {
+    opacity: 1 !important;
+    pointer-events: auto !important; /* Ensure interactable after fade-in */
+}


### PR DESCRIPTION
This commit introduces a fade-out/fade-in animation when transitioning from the login screen to the main application screen, enhancing the user experience.

Key changes:

1.  **CSS for Transitions:**
    *   Added `transition: opacity 0.4s ease-in-out;` to `#login-container` and `#main-app-wrapper`.
    *   Set the default `opacity` of `#main-app-wrapper` (when not hidden by `display:none`) to `0` to prepare it for fading in.
    *   Created utility classes:
        *   `.screen-is-fading-out`: Sets `opacity: 0 !important;` and `pointer-events: none !important;`.
        *   `.screen-is-fading-in`: Sets `opacity: 1 !important;` and `pointer-events: auto !important;`.

2.  **JavaScript Orchestration (`script.js`):**
    *   Modified the `initializeApp()` function to manage the staged transition:
        *   When called, `#login-container` now has `.screen-is-fading-out` applied.
        *   After a 400ms timeout (matching CSS transition):
            *   `#login-container` gets the `.hidden` class (display:none).
            *   `#main-app-wrapper` has its `.hidden` class removed (making it part of the layout but still opacity 0).
            *   A brief nested 20ms timeout ensures the display change is rendered, then `.screen-is-fading-in` is added to `#main-app-wrapper` to trigger its fade-in.
        *   Original `initializeApp` logic (attaching listeners, rendering initial view) is executed within the main timeout, ensuring the main app container is ready.

This creates a smoother and more visually appealing transition between the two primary views of the application.