### PR TITLE
style: Set inline logo dimensions to 5rem x 5rem

### DIFF
--- a/style.css
+++ b/style.css
@@ -733,18 +733,20 @@ body.dark-mode input[type="date"] {
 
 /* Updated styles for .image-logo-dna when part of .logo-title-container */
 .logo-title-container .image-logo-dna {
-    height: 3.2rem;   /* 2rem * 1.6, base for mobile */
-    width: auto;    /* Maintain aspect ratio */
+    height: 5rem;   /* Set to 5rem for all screen sizes */
+    width: 5rem;    /* Set to 5rem for all screen sizes, making it square */
     margin-bottom: 0; /* Vertical alignment handled by flex, remove bottom margin */
     display: block; /* Keep as block, flex item properties will manage layout */
 }
 
+/*
 @media (min-width: 640px) {
     .logo-title-container .image-logo-dna {
-        height: 4rem; /* 2.5rem * 1.6, slightly larger for desktop */
+        height: 4rem; // Previous value, removed for consistent 5rem sizing
     }
-    /* The h1 title already has sm:text-4xl, which increases its size on desktop */
+    // The h1 title already has sm:text-4xl, which increases its size on desktop
 }
+*/
 
 /* Comment out or remove old .image-logo-dna styles if they are no longer needed,
    or ensure they don't conflict. For now, the specific context above handles it.


### PR DESCRIPTION
Adjusted the inline logo (next to the title) to be a 5rem by 5rem square across all screen sizes. Removed previous responsive height adjustments for this specific layout.